### PR TITLE
Fix deploy workflow to use Perl container image

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -15,14 +15,11 @@ jobs:
   setup-infrastructure:
     name: Setup Infrastructure
     runs-on: ubuntu-latest
+    container: perl:stable-slim
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      
-      - name: Setup Perl
-        run: |
-          apt-get update && apt-get install -y perl cpanminus
           
       - name: Create PostgreSQL Database
         run: |


### PR DESCRIPTION
## Summary
Fixes the deploy workflow failure by using the Perl container image where perl and cpanminus are pre-installed.

## Problem
The deploy action was failing with:
```
E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)
```

This occurred because the workflow was trying to install perl and cpanminus on `ubuntu-latest` without sudo permissions.

## Solution
Use `container: perl:stable-slim` (same as our CI workflow) where perl and cpanminus are already installed, eliminating the need for package installation.

## Test plan
- [x] Workflow syntax is valid
- [ ] Deploy workflow will run successfully after merge

🤖 Generated with [Claude Code](https://claude.ai/code)